### PR TITLE
blog skeleton

### DIFF
--- a/_includes/image-header.html
+++ b/_includes/image-header.html
@@ -1,0 +1,19 @@
+<div class="image-header"
+     {% if include.image %}
+      style="background-image:
+              linear-gradient(
+                rgba(0, 0, 0, 0.4),
+                rgba(0, 0, 0, 0.4)
+              ),
+              url('{{ include.image }}')"
+     {% endif %}>
+  <div class="container">
+    <h1>
+      {{ page.title }}
+
+      {% if page.description %}
+        <small>{{ page.description }}</small>
+      {% endif %}
+    </h1>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     {% include head.html %}
   </head>
 
-  <body id="{{ page.title | downcase }}">
+  <body id="{% if page.layout == 'page' %}{{ page.title | downcase }}{% elsif page.layout == 'post' %}post{% endif %}">
     {% include nav.html %}
 
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,8 +3,18 @@ layout: default
 ---
 
 <article>
-    <h1>{{ page.title }}</h1>
-    <p>{{ page.date | date_to_string }} - {{ page.author }}</p>
-
-    {{ content }}
+  <div class="container my-4">
+    <h2 class="post-title">
+      {{ page.title }}
+      <div class="post-info">
+        {{ page.author }}
+        -
+        {{ page.date | date: '%B %e, %Y' }}
+      </div>
+    </h2>
+    <hr>
+    <div class="post-content">
+      {{ content }}
+    </div>
+  </div>
 </article>

--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -1,18 +1,52 @@
 ---
 title: Blog
+description: Latest Updates
 permalink: blog/
 in-nav: true
 ---
 
-<div class="container my-4">
-    <h1>Latest Posts</h1>
+{% include image-header.html image='/assets/img/image-slider/17.png' %}
 
-    <ul>
+<div class="container my-4">
+  <div class="row">
+    <div class="{% if site.categories.announcement %} col-8 {% else %} col {% endif %}">
       {% for post in site.posts %}
-        <li>
-          <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-          <p>{{ post.excerpt }}</p>
-        </li>
+        <div>
+          <h4 class="post-title">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            <div class="post-info">
+              {{ post.author }}
+              -
+              {{ post.date | date: '%B %e, %Y' }}
+            </div>
+          </h4>
+          <p class="excerpt">
+            {{ post.excerpt | strip_html }}
+          </p>
+        </div>
+        {% if forloop.last != true %}
+          <hr class="my-4">
+        {% endif %}
       {% endfor %}
-    </ul>
+    </div>
+    {% if site.categories.announcement %}
+      <div class="col-4">
+        <div class="card announcements">
+          <div class="card-body">
+            <div class="card-title text-center">
+              <h4>Announcements</h4>
+            </div>
+            <hr>
+            {% for post in site.categories.announcement %}
+              <p>
+                <a href="{{ post.url }}">
+                  {{ post.title }}
+                </a>
+              </p>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
 </div>

--- a/_posts/2020-02-04-Hello-World.md
+++ b/_posts/2020-02-04-Hello-World.md
@@ -1,8 +1,6 @@
 ---
-layout: post
-author: brott
+title: Welcome
+author: Brottweiler
 ---
 
-# Welcome
-
-**Hello** there!
+Hello, world!

--- a/assets/css/_dark-mode.scss
+++ b/assets/css/_dark-mode.scss
@@ -42,7 +42,8 @@
     }
   }
 
-  .connect {
+  .connect,
+  .announcements {
     background-color: #222 !important;
     border-color: #111 !important;
   }

--- a/assets/css/components/_image-header.scss
+++ b/assets/css/components/_image-header.scss
@@ -1,0 +1,18 @@
+.image-header {
+  color: #fff;
+  padding: 1rem;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
+  background-image:
+    linear-gradient(
+      rgba(0, 0, 0, 0.4),
+      rgba(0, 0, 0, 0.4)
+    );
+
+  small {
+    display: block;
+    color: #ccc;
+    font-size: 26px;
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,8 +7,11 @@
 @import 'components/nav';
 @import 'components/footer';
 @import 'components/image-slider';
+@import 'components/image-header';
 
 @import 'pages/index';
+@import 'pages/blog';
+@import 'pages/post';
 @import 'pages/play';
 @import 'pages/rules';
 @import 'pages/staff';

--- a/assets/css/pages/_blog.scss
+++ b/assets/css/pages/_blog.scss
@@ -1,0 +1,14 @@
+#blog {
+  .post-info {
+    font-size: 1rem;
+    font-weight: normal;
+  }
+
+  .excerpt {
+    color: #999;
+  }
+
+  .announcements p:last-child {
+    margin: 0;
+  }
+}

--- a/assets/css/pages/_post.scss
+++ b/assets/css/pages/_post.scss
@@ -1,0 +1,6 @@
+#post {
+  .post-info {
+    font-size: 1rem;
+    font-weight: normal;
+  }
+}


### PR DESCRIPTION
presentable blog skeleton theme, I have some ideas for how to make it look nicer (avatar images, rank colors for author names) but thats gonna take a bit of experimenting so don't expect that soon, but this should be enough for you to be able to start posting whatever you may

the "announcements" section pulls posts with `categories: announcement` set in the front matter, and is not shown if there aren't any (so you won't initially have a big empty box)

this pr also adds an `image-header` component that can be used on any page

<img width="991" alt="Screen Shot 2020-02-04 at 11 29 30 PM" src="https://user-images.githubusercontent.com/5340692/73816741-9cdb9180-47a6-11ea-8bd2-a8f3256a6e13.png">
<img width="993" alt="Screen Shot 2020-02-04 at 11 29 41 PM" src="https://user-images.githubusercontent.com/5340692/73816748-a2d17280-47a6-11ea-8c67-1a03fd35e00f.png">

