### PR TITLE
Update rules.html

### DIFF
--- a/_pages/rules.html
+++ b/_pages/rules.html
@@ -103,19 +103,11 @@ in-nav: true
     </div>
   </div>
   <div class="pb-2 mt-4 mb-2 border-bottom">
-      <h2 class="page-heading">F. Tournament</h2>
+      <h2 class="page-heading">F. Bolt & Tournament</h2>
   </div>
   <div class="row">
     <div class="col-md-12">
-      Tournament rules can be found <a href="http://events.oc.tc/rules">here</a>.
-    </div>
-  </div>
-  <div class="pb-2 mt-4 mb-2 border-bottom">
-      <h2 class="page-heading">G. Bolt</h2>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      Bolt rules can be found <a href="https://bolt.rip/rules">here</a>.
+      Bolt and Tournament rules can be found <a href="https://bolt.rip/rules">here</a>.
     </div>
   </div>
 </div>


### PR DESCRIPTION
Tournament previous link redirected to https://bolt.rip/events and now they are together at https://bolt.rip/rules