### PR TITLE
Fix image overflow issue

### DIFF
--- a/assets/css/_global.scss
+++ b/assets/css/_global.scss
@@ -6,3 +6,7 @@ body {
   position: relative;
   min-height: 100%;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
This fix ensures that images don't extend beyond their parent element's width. Makes images responsive on all viewports (desktop, tablet, mobile)

Before fix | After fix
--- | ---
![Image 2021-07-09 at 3 50 19 PM](https://user-images.githubusercontent.com/6914518/125142874-aff63d80-e0cd-11eb-9903-d0c7ee96dfb3.jpg) | ![Image 2021-07-09 at 3 54 42 PM](https://user-images.githubusercontent.com/6914518/125142982-ffd50480-e0cd-11eb-9567-2ad5c5375c74.jpg)

