### PR TITLE
Re-add Strangey to Head of Events staff list

### DIFF
--- a/_data/staff.yml
+++ b/_data/staff.yml
@@ -79,6 +79,8 @@ head of events:
   members:
     - username: Ralloi
       id: e79aa605-fcac-44e2-86eb-30dfc08657d3
+    - username: Strangey
+      id: 621b2aa8-4e5f-4ed8-bd36-0ae2f8952a06
     - username: wylt
       id: d71152ca-187d-43c4-9901-ba001606c655
     - username: PoshEngineer


### PR DESCRIPTION
Strange never left the team when he became admin but the department is separate from that which he is head of, so he should probably still be listed.