### PR TITLE
Remove Cazadorian from media

### DIFF
--- a/_data/staff.yml
+++ b/_data/staff.yml
@@ -99,8 +99,6 @@ media:
       id: a53b7c56-ddc6-4fcb-a121-9a3829aabc28
     - username: Diamyx
       id: f70b7a8f-93b2-480f-9d54-88e21485a042
-    - username: Cazadorian
-      id: 6863869b-4b8c-4445-b778-a8e016775ae4
     - username: MishM0sh
       id: 4011d739-4dfb-41f6-8e60-5179d035cab7
     - username: Flamiix


### PR DESCRIPTION
Even though Cazadorian has the role in Discord servers, he only has it for the sole purpose of viewing channels and fulfilling relevant tasks related to map development.